### PR TITLE
Update Dockerfile to latest ubi min 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:a62d408337bb50546019e2334fdd43ec1ecc150d60f5f195fd324c578c25ab3a
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0ccb9988abbc72d383258d58a7f519a10b637d472f28fbca6eb5fab79ba82a6b
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -44,7 +44,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0d42603bf9f539f28c133e9a13e74cec8d3baaa0165c6f873ff931d50c708d8c
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5bae25288d7cea563733606751e1f5f9606e4332c7755f0e5974091f0e58dac5
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -45,7 +45,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4b3905174e708d2656df72b4800a7abf87284a20ab44b3ef4d7136193caccf9f
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f1c6d887cda1d9dc7f40bcb237e7eef3c5db1674fd156290061cd3cecba290cc
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Update to ubi min 8 to resolve CVE-2021-27219


docker manifest inspect registry.access.redhat.com/ubi8/ubi-minimal:8.4-200.1622548483
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:0ccb9988abbc72d383258d58a7f519a10b637d472f28fbca6eb5fab79ba82a6b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:fb5c56f570becb0565b96b9da1da8b0cfb267e61dacf9863c713ba928f915730",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:5bae25288d7cea563733606751e1f5f9606e4332c7755f0e5974091f0e58dac5",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:f1c6d887cda1d9dc7f40bcb237e7eef3c5db1674fd156290061cd3cecba290cc",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}