### PR TITLE
Update op ver102

### DIFF
--- a/bundle/manifests/ibm-iam-policy-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-policy-operator.clusterserviceversion.yaml
@@ -69,13 +69,13 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-iam-policy-operator
     support: IBM
-    olm.skipRange: '<1.0.1'
+    olm.skipRange: '<1.0.2'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-iam-policy-operator.v1.0.1
+  name: ibm-iam-policy-operator.v1.0.2
   namespace: ibm-common-services
 spec:
   apiservicedefinitions: {}
@@ -287,5 +287,5 @@ spec:
   maturity: stable
   provider:
     name: IBM
-  replaces: ibm-iam-policy-operator.v1.0.0
-  version: 1.0.1
+  replaces: ibm-iam-policy-operator.v1.0.1
+  version: 1.0.2

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "1.0.1"
+	Version = "1.0.2"
 )


### PR DESCRIPTION
Update operator version to 1.0.2 to build the release-cd pipeline.

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47811